### PR TITLE
feat: paymentConfig param for dynamic redirectUrl

### DIFF
--- a/README-ENG.md
+++ b/README-ENG.md
@@ -31,7 +31,7 @@ Set the following environment variables in your `.env` file:
 - `SIMPLEPAY_MERCHANT_KEY_HUF` Your Simplepay secret merchant key. Set `SIMPLEPAY_MERCHANT_KEY_EUR` and `SIMPLEPAY_MERCHANT_KEY_USD` for accepting EUR and USD payments.
 - `SIMPLEPAY_MERCHANT_ID_HUF` Your Simplepay merchant id. Set `SIMPLEPAY_MERCHANT_ID_EUR` and `SIMPLEPAY_MERCHANT_ID_USD` for accepting EUR and USD payments.
 - `SIMPLEPAY_PRODUCTION` If it set to `true`, it will use production environment, otherwise it will use sandbox environment.
-- `SIMPLEPAY_REDIRECT_URL` The URL of your site, where the customer will be redirected after the payment.
+- `SIMPLEPAY_REDIRECT_URL` The URL of your site, where the customer will be redirected after the payment. Can also be provided when starting a payment.
 
 ## Usage
 
@@ -60,6 +60,8 @@ try {
       zip: '1234',
       address: 'Sehol u. 0',
     },
+  }, {
+    redirectUrl: 'http://url.to.redirect' // optional, defaults to the value of the SIMPLEPAY_REDIRECT_URL environment variable
   })
   return response
 } catch (error) {

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pnpm add simplepay-js-sdk
 - `SIMPLEPAY_MERCHANT_KEY_HUF` A te SimplePay titkos kereskedői kulcsod. Állítsd be a `SIMPLEPAY_MERCHANT_KEY_EUR` és `SIMPLEPAY_MERCHANT_KEY_USD` értékeket EUR és USD fizetések elfogadásához.
 - `SIMPLEPAY_MERCHANT_ID_HUF` A te SimplePay kereskedői azonosítód. Állítsd be a `SIMPLEPAY_MERCHANT_ID_EUR` és `SIMPLEPAY_MERCHANT_ID_USD` értékeket EUR és USD fizetések elfogadásához.
 - `SIMPLEPAY_PRODUCTION` Ha `true`-ra van állítva, éles környezetet használ, egyébként teszt környezetet.
-- `SIMPLEPAY_REDIRECT_URL` A te weboldalad URL-je, ahova a vásárló átirányításra kerül a fizetés után.
+- `SIMPLEPAY_REDIRECT_URL` A te weboldalad URL-je, ahova a vásárló átirányításra kerül a fizetés után. Ez a fizetés indításakor is megadható.
 
 ## Használat
 
@@ -60,6 +60,8 @@ try {
       zip: '1234',
       address: 'Sehol u. 0',
     },
+  }, {
+    redirectUrl: 'http://url.to.redirect' // opcionális, alapértelmezetten a SIMPLEPAY_REDIRECT_URL környezeti változó értéke
   })
   return response
 } catch (error) {

--- a/src/oneTime.ts
+++ b/src/oneTime.ts
@@ -1,8 +1,8 @@
 import crypto from 'crypto'
-import { PaymentData, SimplePayRequestBody } from './types'
+import { PaymentConfig, PaymentData, SimplePayRequestBody } from './types'
 import { simplepayLogger, getSimplePayConfig, toISO8601DateString, makeSimplePayRequest } from './utils'
 
-const startPayment = async (paymentData: PaymentData) => {
+const startPayment = async (paymentData: PaymentData, config: PaymentConfig = {}) => {
     simplepayLogger({ function: 'SimplePay/startPayment', paymentData })
     const currency = paymentData.currency || 'HUF'
     const { MERCHANT_KEY, MERCHANT_ID, API_URL_PAYMENT, SDK_VERSION } = getSimplePayConfig(currency)
@@ -23,7 +23,7 @@ const startPayment = async (paymentData: PaymentData) => {
         methods: [paymentData.method || 'CARD'],
         total: String(paymentData.total),
         timeout: toISO8601DateString(new Date(Date.now() + 30 * 60 * 1000)),
-        url: process.env.SIMPLEPAY_REDIRECT_URL || 'http://url.to.redirect',
+        url: config.redirectUrl || process.env.SIMPLEPAY_REDIRECT_URL || 'http://url.to.redirect',
         invoice: paymentData.invoice,
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,10 @@ export interface PaymentData {
     }
 }
 
+export interface PaymentConfig {
+    redirectUrl?: string
+}
+
 export type ISO8601DateString = string
 export interface Recurring {
     times: number,


### PR DESCRIPTION
This PR introduces a second parameter for the startPayment function, that contains technical configurations for the payment. Currently the only configuration is the redirectUrl of the payment. 
If no url is provided in the config it will use the env var as previously.